### PR TITLE
Updated flags for StanHeaders 2.26

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ LinkingTo:
     dparser (>= 1.3.1-10),
     Rcpp (>= 1.0.8),
     RcppEigen (>= 0.3.3.9.2),
-    StanHeaders (>= 2.21.0.7)
+    StanHeaders (>= 2.21.0.7),
+    RcppParallel (>= 2.21.0.7)
 Biarch: true
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -23,8 +23,7 @@ unlink("src/tran.g.d_parser.c")
                                .badStan)),
             .in)
 
-.in <- gsub("@SL@", "", paste(capture.output(StanHeaders:::LdFlags()), capture.output(RcppParallel:::RcppParallelLibs())),
-            .in)
+.in <- gsub("@SL@", paste(capture.output(StanHeaders:::LdFlags()), capture.output(RcppParallel:::RcppParallelLibs())), .in)
 
 if (.Platform$OS.type == "windows" && !file.exists("src/Makevars.win")) {
   .in <- gsub("@CXX14STD@", "-std=c++1y", .in)

--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -17,13 +17,13 @@ unlink("src/tran.g.d_parser.c")
 
 .badStan <- ""
 .in <- gsub("@SH@", gsub("-I", "-@ISYSTEM@",
-                         paste(## capture.output(StanHeaders:::CxxFlags()),
-                               ## capture.output(RcppParallel:::CxxFlags()),
+                         paste(capture.output(StanHeaders:::CxxFlags()),
+                               capture.output(RcppParallel:::CxxFlags()),
                                paste0("-@ISYSTEM@'", system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE), "'"),
                                .badStan)),
             .in)
 
-.in <- gsub("@SL@", "", ##paste(capture.output(StanHeaders:::LdFlags()), capture.output(RcppParallel:::RcppParallelLibs())),
+.in <- gsub("@SL@", "", paste(capture.output(StanHeaders:::LdFlags()), capture.output(RcppParallel:::RcppParallelLibs())),
             .in)
 
 if (.Platform$OS.type == "windows" && !file.exists("src/Makevars.win")) {

--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -17,13 +17,13 @@ unlink("src/tran.g.d_parser.c")
 
 .badStan <- ""
 .in <- gsub("@SH@", gsub("-I", "-@ISYSTEM@",
-                         paste(capture.output(StanHeaders:::CxxFlags()),
-                               capture.output(RcppParallel:::CxxFlags()),
+                         paste(capture.output(StanHeaders:::CxxFlags()),  # nolint
+                               capture.output(RcppParallel:::CxxFlags()),  # nolint
                                paste0("-@ISYSTEM@'", system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE), "'"),
                                .badStan)),
             .in)
 
-.in <- gsub("@SL@", paste(capture.output(StanHeaders:::LdFlags()), capture.output(RcppParallel:::RcppParallelLibs())), .in)
+.in <- gsub("@SL@", paste(capture.output(StanHeaders:::LdFlags()), capture.output(RcppParallel:::RcppParallelLibs())), .in)  # nolint
 
 if (.Platform$OS.type == "windows" && !file.exists("src/Makevars.win")) {
   .in <- gsub("@CXX14STD@", "-std=c++1y", .in)


### PR DESCRIPTION
This PR re-enables your package's compilation and linker flags for compatibility with future StanHeaders versions.

I've run the checking workflows on my own fork and all has passed, but let me know if anything breaks again and I'll chase it down